### PR TITLE
Bugfix/fixed response object to include headers and body in outbound progress notification

### DIFF
--- a/examples/collections/dfsp/p2p_failed_tests.json
+++ b/examples/collections/dfsp/p2p_failed_tests.json
@@ -66,28 +66,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain fspiop",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop-source')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop-source')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -133,28 +133,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -200,28 +200,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -267,28 +267,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain accept",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               }
             ]
@@ -514,21 +514,21 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               }
             ]
@@ -575,21 +575,21 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               }
             ]
@@ -636,14 +636,14 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               }
             ]
@@ -868,28 +868,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -972,28 +972,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain Accept",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1076,28 +1076,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1180,28 +1180,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain fspiop",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1432,28 +1432,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1537,28 +1537,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain Accept",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1642,21 +1642,21 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               }
             ]
@@ -1952,28 +1952,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -2027,28 +2027,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -2095,28 +2095,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain fspiop-source header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop-source')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop-source')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -2170,28 +2170,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain accept header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -2490,28 +2490,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -2559,28 +2559,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -2628,28 +2628,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain accept header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -2734,28 +2734,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain quote",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('quote')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('quote')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2839,28 +2839,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transaction",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transaction')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transaction')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2940,28 +2940,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain payer",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payer')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payer')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3045,28 +3045,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3150,28 +3150,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3255,28 +3255,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3360,28 +3360,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3465,28 +3465,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3570,28 +3570,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -3888,28 +3888,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transferId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transferId')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3964,28 +3964,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain payerFsp",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payerFsp')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payerFsp')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4040,28 +4040,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain payeeFsp",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payeeFsp')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payeeFsp')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4116,28 +4116,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4192,28 +4192,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4268,28 +4268,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain expiration",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('expiration')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('expiration')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4344,28 +4344,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('ilpPacket')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('ilpPacket')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4420,28 +4420,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain condition",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('condition')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('condition')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4740,28 +4740,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4816,28 +4816,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4892,28 +4892,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transferId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transferId')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4968,28 +4968,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain expiration",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('expiration')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('expiration')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -5081,28 +5081,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain partyIdType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('partyIdType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('partyIdType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5186,28 +5186,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transaction",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transaction')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transaction')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5291,28 +5291,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain quoteId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('quoteId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('quoteId')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5396,28 +5396,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amountType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amountType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amountType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5501,28 +5501,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5606,28 +5606,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5711,28 +5711,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5816,28 +5816,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -5921,28 +5921,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]

--- a/examples/collections/dfsp/p2p_happy_path_demo.json
+++ b/examples/collections/dfsp/p2p_happy_path_demo.json
@@ -389,28 +389,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain fspiop",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop-source')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop-source')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -456,28 +456,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -523,28 +523,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain content-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('content')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('content')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -590,28 +590,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain accept",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               }
             ]
@@ -1009,28 +1009,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain Accept",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1113,28 +1113,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1217,28 +1217,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain fspiop",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               }
             ]
@@ -1534,28 +1534,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain date-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('date')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('date')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -1609,28 +1609,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain fspiop-source header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('fspiop-source')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('fspiop-source')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -1684,28 +1684,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain accept header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('accept')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('accept')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3102')"
                 ]
               },
               {
@@ -1797,28 +1797,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain quote",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('quote')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('quote')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -1902,28 +1902,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transaction",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transaction')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transaction')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2003,28 +2003,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain payer",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payer')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payer')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2108,28 +2108,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2213,28 +2213,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2318,28 +2318,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2423,28 +2423,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2528,28 +2528,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2633,28 +2633,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -2951,28 +2951,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transferId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transferId')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3027,28 +3027,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain payerFsp",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payerFsp')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payerFsp')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3103,28 +3103,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain payeeFsp",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('payeeFsp')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('payeeFsp')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3179,28 +3179,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId-type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3255,28 +3255,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3331,28 +3331,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain expiration",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('expiration')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('expiration')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3407,28 +3407,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('ilpPacket')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('ilpPacket')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3483,28 +3483,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain condition",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('condition')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('condition')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3803,28 +3803,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3879,28 +3879,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -3955,28 +3955,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain transferId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transferId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transferId')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4031,28 +4031,28 @@
                 "id": 2,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain expiration",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('expiration')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('expiration')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain '3102'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               },
               {
@@ -4144,28 +4144,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain partyIdType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('partyIdType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('partyIdType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4249,28 +4249,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transaction",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transaction')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transaction')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4354,28 +4354,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain quoteId",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('quoteId')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('quoteId')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4459,28 +4459,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amountType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amountType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amountType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4564,28 +4564,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain amount",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('amount')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('amount')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4669,28 +4669,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain currency",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('currency')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('currency')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4774,28 +4774,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4879,28 +4879,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]
@@ -4984,28 +4984,28 @@
                 "id": 3,
                 "description": "Response should contain error information",
                 "exec": [
-                  "expect(response.data).to.have.property('errorInformation')"
+                  "expect(response.body).to.have.property('errorInformation')"
                 ]
               },
               {
                 "id": 4,
                 "description": "Response should contain error code",
                 "exec": [
-                  "expect(response.data.errorInformation).to.have.property('errorCode')"
+                  "expect(response.body.errorInformation).to.have.property('errorCode')"
                 ]
               },
               {
                 "id": 5,
                 "description": "Response should contain transactionType",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('transactionType')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('transactionType')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Response should contain '3100'",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.include('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.include('3100')"
                 ]
               }
             ]

--- a/examples/collections/dfsp/sample.json
+++ b/examples/collections/dfsp/sample.json
@@ -244,7 +244,7 @@
                 "id": 2,
                 "description": "Callback body should contain party",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -393,7 +393,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -434,7 +434,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -475,7 +475,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -516,7 +516,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -617,7 +617,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -657,7 +657,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -697,7 +697,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -737,7 +737,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -848,7 +848,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -892,7 +892,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -937,7 +937,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -982,7 +982,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1027,7 +1027,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1136,7 +1136,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -1179,7 +1179,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1223,7 +1223,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1267,7 +1267,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1311,7 +1311,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1441,7 +1441,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -1496,7 +1496,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1551,7 +1551,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1606,7 +1606,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1662,7 +1662,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1717,7 +1717,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1759,7 +1759,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1862,7 +1862,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -1903,7 +1903,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1944,7 +1944,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -1985,7 +1985,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2084,7 +2084,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -2123,7 +2123,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2162,7 +2162,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2201,7 +2201,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2300,7 +2300,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -2339,7 +2339,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2378,7 +2378,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2417,7 +2417,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2516,7 +2516,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -2555,7 +2555,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2594,7 +2594,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2633,7 +2633,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2732,7 +2732,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -2771,7 +2771,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2810,7 +2810,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2849,7 +2849,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -2948,7 +2948,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -2987,7 +2987,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3026,7 +3026,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3065,7 +3065,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3333,7 +3333,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -3457,7 +3457,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3581,7 +3581,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3705,7 +3705,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3830,7 +3830,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -3954,7 +3954,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4061,7 +4061,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4133,7 +4133,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4295,7 +4295,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -4366,7 +4366,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4437,7 +4437,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4508,7 +4508,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4580,7 +4580,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4651,7 +4651,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4722,7 +4722,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4793,7 +4793,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4864,7 +4864,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4917,7 +4917,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]
@@ -4988,7 +4988,7 @@
                 "id": 2,
                 "description": "Response data.errorInformation.errorCode to be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_11_bulk_transfers.json
+++ b/examples/collections/hub/hub_11_bulk_transfers.json
@@ -1191,7 +1191,7 @@
                 "id": 2,
                 "description": "Payerfsp position after Payer ABORT should be same as position before prepare.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payerfspPositionBeforePrepare)"
+                  "expect(response.body[0].value).to.equal(+environment.payerfspPositionBeforePrepare)"
                 ]
               }
             ]
@@ -1225,7 +1225,7 @@
                 "id": 2,
                 "description": "Payeefsp position after Payee ABORT should be same as position before prepare.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
+                  "expect(response.body[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_3_transaction_request_service.json
+++ b/examples/collections/hub/hub_3_transaction_request_service.json
@@ -879,14 +879,14 @@
                 "id": 2,
                 "description": "Check Generic validation error ",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal(\"Malformed syntax - .requestBody should be object\")"
+                  "expect(response.body.errorInformation.errorDescription).to.equal(\"Malformed syntax - .requestBody should be object\")"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3101",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3101')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3101')"
                 ]
               }
             ]
@@ -926,14 +926,14 @@
                 "id": 2,
                 "description": "Missing mandatory element - date is required",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'date'\")"
+                  "expect(response.body.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'date'\")"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3102",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -1089,14 +1089,14 @@
                 "id": 2,
                 "description": "Missing mandatory element - fspiop-source is required",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'fspiop-source'\")"
+                  "expect(response.body.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'fspiop-source'\")"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3102",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -1253,14 +1253,14 @@
                 "id": 2,
                 "description": "Check Unacceptable version requested",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal('Unacceptable version requested - Client supplied a protocol version which is not supported by the server')"
+                  "expect(response.body.errorInformation.errorDescription).to.equal('Unacceptable version requested - Client supplied a protocol version which is not supported by the server')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3001",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3001')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3001')"
                 ]
               }
             ]
@@ -1301,14 +1301,14 @@
                 "id": 2,
                 "description": "Check Malformed syntax - Unsupported Media Type",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal('Malformed syntax - Unsupported Media Type')"
+                  "expect(response.body.errorInformation.errorDescription).to.equal('Malformed syntax - Unsupported Media Type')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3101",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3101')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3101')"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_4_quoting_service.json
+++ b/examples/collections/hub/hub_4_quoting_service.json
@@ -275,14 +275,14 @@
                 "id": 2,
                 "description": "Check Missing mandatory element - Date",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include(\"Missing mandatory element - .header should have required property 'date'\")"
+                  "expect(response.body.errorInformation.errorDescription).to.include(\"Missing mandatory element - .header should have required property 'date'\")"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3102",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -375,14 +375,14 @@
                 "id": 2,
                 "description": "Check Missing mandatory element - Invalid accept header",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'accept'\")"
+                  "expect(response.body.errorInformation.errorDescription).to.equal(\"Missing mandatory element - .header should have required property 'accept'\")"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3101",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -442,14 +442,14 @@
                 "id": 2,
                 "description": "Check Missing mandatory element",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('Missing mandatory element')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('Missing mandatory element')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3102",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3102')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3102')"
                 ]
               }
             ]
@@ -499,14 +499,14 @@
                 "id": 2,
                 "description": "Check Malformed syntax",
                 "exec": [
-                  "expect(response.data.errorInformation.errorDescription).to.include('Malformed syntax')"
+                  "expect(response.body.errorInformation.errorDescription).to.include('Malformed syntax')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Check Error code 3101",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3101')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3101')"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_5_transfer_negative_scenarios.json
+++ b/examples/collections/hub/hub_5_transfer_negative_scenarios.json
@@ -222,7 +222,7 @@
                 "id": 2,
                 "description": "Payeefsp position after Payee ABORT should be same as position before prepare.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
+                  "expect(response.body[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
                 ]
               },
               {
@@ -429,7 +429,7 @@
                 "id": 2,
                 "description": "Payerfsp position after Payer ABORT should be same as position before prepare.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payerfspPositionBeforePrepare)"
+                  "expect(response.body[0].value).to.equal(+environment.payerfspPositionBeforePrepare)"
                 ]
               }
             ]
@@ -463,7 +463,7 @@
                 "id": 2,
                 "description": "Payeefsp position after Payee ABORT should be same as position before prepare.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
+                  "expect(response.body[0].value).to.equal(+environment.payeefspPositionBeforePrepare)"
                 ]
               }
             ]
@@ -768,7 +768,7 @@
                 "id": 2,
                 "description": "Payerfsp position after Payee Invalid Fulfillment should be same as position before transfer.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payerfspPositionBeforeTransfer)"
+                  "expect(response.body[0].value).to.equal(+environment.payerfspPositionBeforeTransfer)"
                 ]
               }
             ]
@@ -815,7 +815,7 @@
                 "id": 2,
                 "description": "Payeefsp position after Payee Invalid Fulfillment should be same as position before transfer.",
                 "exec": [
-                  "expect(response.data[0].value).to.equal(+environment.payeefspPositionBeforeTransfer)"
+                  "expect(response.body[0].value).to.equal(+environment.payeefspPositionBeforeTransfer)"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_6_participant_inactive_stop_transfers.json
+++ b/examples/collections/hub/hub_6_participant_inactive_stop_transfers.json
@@ -39,7 +39,7 @@
                 "id": 2,
                 "description": "FSP is inactive",
                 "exec": [
-                  "expect(response.data.isActive).to.equal(0)"
+                  "expect(response.body.isActive).to.equal(0)"
                 ]
               }
             ]
@@ -73,7 +73,7 @@
                 "id": 2,
                 "description": "FSP is inactive",
                 "exec": [
-                  "expect(response.data.isActive).to.equal(0)"
+                  "expect(response.body.isActive).to.equal(0)"
                 ]
               }
             ]
@@ -326,7 +326,7 @@
                 "id": 2,
                 "description": "FSP is active",
                 "exec": [
-                  "expect(response.data.isActive).to.equal(1)"
+                  "expect(response.body.isActive).to.equal(1)"
                 ]
               }
             ]
@@ -360,7 +360,7 @@
                 "id": 2,
                 "description": "FSP is active",
                 "exec": [
-                  "expect(response.data.isActive).to.equal(1)"
+                  "expect(response.body.isActive).to.equal(1)"
                 ]
               }
             ]

--- a/examples/collections/hub/hub_9_accented_and_spl_chars.json
+++ b/examples/collections/hub/hub_9_accented_and_spl_chars.json
@@ -616,7 +616,7 @@
                 "id": 3,
                 "description": "errorCode should be 3100",
                 "exec": [
-                  "expect(response.data.errorInformation.errorCode).to.equal('3100')"
+                  "expect(response.body.errorInformation.errorCode).to.equal('3100')"
                 ]
               }
             ]

--- a/examples/collections/hub/settlements/hub_2_settlements.json
+++ b/examples/collections/hub/settlements/hub_2_settlements.json
@@ -222,8 +222,8 @@
                 "id": 1,
                 "description": "Status to be 200 or error code 3001",
                 "exec": [
-                  "if (response.data.errorInformation) {",
-                  "  expect(response.data.errorInformation.errorCode).to.equal(\"3100\")",
+                  "if (response.body.errorInformation) {",
+                  "  expect(response.body.errorInformation.errorCode).to.equal(\"3100\")",
                   "} else {",
                   "  expect(response.status).to.equal(200)  ",
                   "}",
@@ -234,10 +234,10 @@
                 "id": 2,
                 "description": "State to be OPEN or Window is empty",
                 "exec": [
-                  "if (response.data.errorInformation) {",
-                  "  expect(response.data.errorInformation.errorDescription).to.equal(`Generic validation error - Window ${environment.openWindowID} is empty`)",
+                  "if (response.body.errorInformation) {",
+                  "  expect(response.body.errorInformation.errorDescription).to.equal(`Generic validation error - Window ${environment.openWindowID} is empty`)",
                   "} else {",
-                  "  expect(response.data.state).to.equal('OPEN') ",
+                  "  expect(response.body.state).to.equal('OPEN') ",
                   "}"
                 ]
               }
@@ -1237,7 +1237,7 @@
                 "id": 2,
                 "description": "State should be OPEN",
                 "exec": [
-                  "expect(response.data.state).to.equal('OPEN')"
+                  "expect(response.body.state).to.equal('OPEN')"
                 ]
               }
             ]
@@ -1299,63 +1299,63 @@
                 "id": 2,
                 "description": "Settlement State should be PENDING_SETTLEMENT",
                 "exec": [
-                  "expect(response.data.state).to.equal('PENDING_SETTLEMENT')"
+                  "expect(response.body.state).to.equal('PENDING_SETTLEMENT')"
                 ]
               },
               {
                 "id": 3,
                 "description": "Number of associated windows should be 1",
                 "exec": [
-                  "expect(response.data.settlementWindows.length).to.equal(1)"
+                  "expect(response.body.settlementWindows.length).to.equal(1)"
                 ]
               },
               {
                 "id": 4,
                 "description": "Associated Settlement Window ID should be as closedWindowId",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].id).to.eql(environment.closedWindowID)"
+                  "expect(response.body.settlementWindows[0].id).to.eql(environment.closedWindowID)"
                 ]
               },
               {
                 "id": 5,
                 "description": "Associated Settlement Window state should be PENDING_SETTLEMENT ",
                 "exec": [
-                  "expect(response.data.state).to.equal('PENDING_SETTLEMENT')"
+                  "expect(response.body.state).to.equal('PENDING_SETTLEMENT')"
                 ]
               },
               {
                 "id": 6,
                 "description": "Associated number of participants should be 4",
                 "exec": [
-                  "expect(response.data.participants.length).to.equal(4)"
+                  "expect(response.body.participants.length).to.equal(4)"
                 ]
               },
               {
                 "id": 7,
                 "description": "DEFERREDNET calculation for testfsp1 should be 80.09",
                 "exec": [
-                  "expect(response.data.participants[0].accounts[0].netSettlementAmount.amount).to.equal(80.09)"
+                  "expect(response.body.participants[0].accounts[0].netSettlementAmount.amount).to.equal(80.09)"
                 ]
               },
               {
                 "id": 8,
                 "description": "DEFERREDNET calculation for testfsp2 should be -75.667",
                 "exec": [
-                  "expect(response.data.participants[1].accounts[0].netSettlementAmount.amount).to.equal(-75.667)"
+                  "expect(response.body.participants[1].accounts[0].netSettlementAmount.amount).to.equal(-75.667)"
                 ]
               },
               {
                 "id": 9,
                 "description": "DEFERREDNET calculation for testfsp3 should be -10.1857",
                 "exec": [
-                  "expect(response.data.participants[2].accounts[0].netSettlementAmount.amount).to.equal(-10.1857)"
+                  "expect(response.body.participants[2].accounts[0].netSettlementAmount.amount).to.equal(-10.1857)"
                 ]
               },
               {
                 "id": 10,
                 "description": "DEFERREDNET calculation for testfsp4 should be 5.7627",
                 "exec": [
-                  "expect(response.data.participants[3].accounts[0].netSettlementAmount.amount).to.equal(5.7627)"
+                  "expect(response.body.participants[3].accounts[0].netSettlementAmount.amount).to.equal(5.7627)"
                 ]
               }
             ]
@@ -1682,35 +1682,35 @@
                 "id": 2,
                 "description": "Settlement Id should be as expected",
                 "exec": [
-                  "expect(response.data.id).to.equal(environment.settlementId)"
+                  "expect(response.body.id).to.equal(environment.settlementId)"
                 ]
               },
               {
                 "id": 3,
                 "description": "Settlement state should be PS_TRANSFERS_RECORDED",
                 "exec": [
-                  "expect(response.data.state).to.equal(\"PS_TRANSFERS_RECORDED\")"
+                  "expect(response.body.state).to.equal(\"PS_TRANSFERS_RECORDED\")"
                 ]
               },
               {
                 "id": 4,
                 "description": "Settlement Window ID should be closed",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].id).to.equal(environment.closedWindowID)"
+                  "expect(response.body.settlementWindows[0].id).to.equal(environment.closedWindowID)"
                 ]
               },
               {
                 "id": 5,
                 "description": "Settlement Window State should be PENDING_SETTLEMENT",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
+                  "expect(response.body.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
                 ]
               },
               {
                 "id": 6,
                 "description": "Participant Accounts state is PS_TRANSFERS_RECORDED",
                 "exec": [
-                  "response.data.participants.forEach(participant => {",
+                  "response.body.participants.forEach(participant => {",
                   "\tparticipant.accounts.forEach(account => {",
                   "      expect(account.state).to.equal(\"PS_TRANSFERS_RECORDED\")",
                   "    })",
@@ -2069,35 +2069,35 @@
                 "id": 2,
                 "description": "Settlement Id should be as expected",
                 "exec": [
-                  "expect(response.data.id).to.equal(environment.settlementId)"
+                  "expect(response.body.id).to.equal(environment.settlementId)"
                 ]
               },
               {
                 "id": 3,
                 "description": "Settlement state should be PS_TRANSFERS_RESERVED",
                 "exec": [
-                  "expect(response.data.state).to.equal(\"PS_TRANSFERS_RESERVED\")"
+                  "expect(response.body.state).to.equal(\"PS_TRANSFERS_RESERVED\")"
                 ]
               },
               {
                 "id": 4,
                 "description": "Settlement Window ID should be closed",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].id).to.equal(environment.closedWindowID)"
+                  "expect(response.body.settlementWindows[0].id).to.equal(environment.closedWindowID)"
                 ]
               },
               {
                 "id": 5,
                 "description": "Settlement Window State should be PENDING_SETTLEMENT",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
+                  "expect(response.body.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
                 ]
               },
               {
                 "id": 6,
                 "description": "Participant Accounts state is PS_TRANSFERS_RESERVED",
                 "exec": [
-                  "response.data.participants.forEach(participant => {",
+                  "response.body.participants.forEach(participant => {",
                   "\tparticipant.accounts.forEach(account => {",
                   "      expect(account.state).to.equal(\"PS_TRANSFERS_RESERVED\")",
                   "    })",
@@ -2450,35 +2450,35 @@
                 "id": 2,
                 "description": "Settlement Id should be as expected",
                 "exec": [
-                  "expect(response.data.id).to.equal(environment.settlementId)"
+                  "expect(response.body.id).to.equal(environment.settlementId)"
                 ]
               },
               {
                 "id": 3,
                 "description": "Settlement state should be PS_TRANSFERS_COMMITTED",
                 "exec": [
-                  "expect(response.data.state).to.equal(\"PS_TRANSFERS_COMMITTED\")"
+                  "expect(response.body.state).to.equal(\"PS_TRANSFERS_COMMITTED\")"
                 ]
               },
               {
                 "id": 4,
                 "description": "Settlement Window ID should be closed",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].id).to.equal(environment.closedWindowID)"
+                  "expect(response.body.settlementWindows[0].id).to.equal(environment.closedWindowID)"
                 ]
               },
               {
                 "id": 5,
                 "description": "Settlement Window State should be PENDING_SETTLEMENT",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
+                  "expect(response.body.settlementWindows[0].state).to.equal(\"PENDING_SETTLEMENT\")"
                 ]
               },
               {
                 "id": 6,
                 "description": "Participant Accounts state is PS_TRANSFERS_COMMITTED",
                 "exec": [
-                  "response.data.participants.forEach(participant => {",
+                  "response.body.participants.forEach(participant => {",
                   "\tparticipant.accounts.forEach(account => {",
                   "      expect(account.state).to.equal(\"PS_TRANSFERS_COMMITTED\")",
                   "    })",
@@ -2829,35 +2829,35 @@
                 "id": 2,
                 "description": "Settlement Id should be as expected",
                 "exec": [
-                  "expect(response.data.id).to.equal(environment.settlementId)"
+                  "expect(response.body.id).to.equal(environment.settlementId)"
                 ]
               },
               {
                 "id": 3,
                 "description": "Settlement state should be SETTLED",
                 "exec": [
-                  "expect(response.data.state).to.equal(\"SETTLED\")"
+                  "expect(response.body.state).to.equal(\"SETTLED\")"
                 ]
               },
               {
                 "id": 4,
                 "description": "Settlement Window ID should be closed",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].id).to.equal(environment.closedWindowID)"
+                  "expect(response.body.settlementWindows[0].id).to.equal(environment.closedWindowID)"
                 ]
               },
               {
                 "id": 5,
                 "description": "Settlement Window State should be SETTLED",
                 "exec": [
-                  "expect(response.data.settlementWindows[0].state).to.equal(\"SETTLED\")"
+                  "expect(response.body.settlementWindows[0].state).to.equal(\"SETTLED\")"
                 ]
               },
               {
                 "id": 6,
                 "description": "Participant Accounts state is SETTLED",
                 "exec": [
-                  "response.data.participants.forEach(participant => {",
+                  "response.body.participants.forEach(participant => {",
                   "\tparticipant.accounts.forEach(account => {",
                   "      expect(account.state).to.equal(\"SETTLED\")",
                   "    })",

--- a/examples/collections/provisioning/testingtoolkitdfsp.json
+++ b/examples/collections/provisioning/testingtoolkitdfsp.json
@@ -30,7 +30,7 @@
                 "id": 1,
                 "description": "status to be 201 if not exists or 400 if exists",
                 "exec": [
-                  "if (response.data.errorInformation) {",
+                  "if (response.body.errorInformation) {",
                   "  expect(response.status).to.equal(400)",
                   "} else {",
                   "  expect(response.status).to.equal(201)",
@@ -72,7 +72,7 @@
                 "id": 1,
                 "description": "status to be 201 if not exists or 500 if exists",
                 "exec": [
-                  "if (response.data.errorInformation) {",
+                  "if (response.body.errorInformation) {",
                   "  expect(response.status).to.equal(500)",
                   "} else {",
                   "  expect(response.status).to.equal(201)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc.",
   "contributors": [

--- a/spec_files/reports/templates/newman/html_template.html
+++ b/spec_files/reports/templates/newman/html_template.html
@@ -668,6 +668,25 @@ input:checked + .slider:before {
                             </div>
                         </div>
                         {{/if}}
+                        {{#if response.headers}}
+                        <div class="row">
+                        <div class="col-sm-12 mb-3">
+                            <div class="card-deck">
+                            <div class="card border-info" style="width: 50rem;">
+                                <div class="card-body">
+                                    <h5 class="card-title text-uppercase text-white text-center bg-info">Response Headers</h5>
+                                        <div class="dyn-height">
+                                                <pre><code id="copyText-responseHeaders-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.headers}}</code></pre>
+                                        </div>
+                                        <div class="card-footer">
+                                            <button class="btn btn-outline-secondary btn-sm copyButton" type="button" data-clipboard-action="copy" data-clipboard-target="#copyText-responseHeaders-{{../id}}-{{request.id}}">Copy to Clipboard</button>
+                                        </div>
+                                </div>
+                            </div>
+                            </div>
+                            </div>
+                        </div>
+                        {{/if}}
                         {{#if response.body}}
                         <div class="row">
                         <div class="col-sm-12 mb-3">

--- a/spec_files/reports/templates/newman/html_template.html
+++ b/spec_files/reports/templates/newman/html_template.html
@@ -668,7 +668,7 @@ input:checked + .slider:before {
                             </div>
                         </div>
                         {{/if}}
-                        {{#if response.data}}
+                        {{#if response.body}}
                         <div class="row">
                         <div class="col-sm-12 mb-3">
                             <div class="card-deck">
@@ -676,7 +676,7 @@ input:checked + .slider:before {
                                 <div class="card-body">
                                     <h5 class="card-title text-uppercase text-white text-center bg-info">Response Body</h5>
                                         <div class="dyn-height">
-                                                <pre><code id="copyText-responseBody-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.data}}</code></pre>
+                                                <pre><code id="copyText-responseBody-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.body}}</code></pre>
                                         </div>
                                         <div class="card-footer">
                                             <button class="btn btn-outline-secondary btn-sm copyButton" type="button" data-clipboard-action="copy" data-clipboard-target="#copyText-responseBody-{{../id}}-{{request.id}}">Copy to Clipboard</button>

--- a/spec_files/reports/templates/newman/pdf_template.html
+++ b/spec_files/reports/templates/newman/pdf_template.html
@@ -626,7 +626,7 @@ input:checked + .slider:before {
                             </div>
                         </div>
                         {{/if}}
-                        {{#if response.data}}
+                        {{#if response.body}}
                         <div class="row">
                         <div class="col-sm-12 mb-3">
                             <div class="card-deck">
@@ -634,7 +634,7 @@ input:checked + .slider:before {
                                 <div class="card-body">
                                     <h5 class="card-title text-uppercase text-white text-center bg-info">Response Body</h5>
                                         <div class="dyn-height">
-                                                <pre><code id="copyText-responseBody-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.data}}</code></pre>
+                                                <pre><code id="copyText-responseBody-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.body}}</code></pre>
                                         </div>
                                 </div>
                             </div>

--- a/spec_files/reports/templates/newman/pdf_template.html
+++ b/spec_files/reports/templates/newman/pdf_template.html
@@ -626,6 +626,22 @@ input:checked + .slider:before {
                             </div>
                         </div>
                         {{/if}}
+                        {{#if response.headers}}
+                        <div class="row">
+                        <div class="col-sm-12 mb-3">
+                            <div class="card-deck">
+                            <div class="card border-info" style="width: 50rem;">
+                                <div class="card-body">
+                                    <h5 class="card-title text-uppercase text-white text-center bg-info">Response Headers</h5>
+                                        <div class="dyn-height">
+                                                <pre><code id="copyText-responseHeaders-{{../id}}-{{request.id}}" class="prettyPrint">{{jsonStringify response.headers}}</code></pre>
+                                        </div>
+                                </div>
+                            </div>
+                            </div>
+                            </div>
+                        </div>
+                        {{/if}}
                         {{#if response.body}}
                         <div class="row">
                         <div class="col-sm-12 mb-3">

--- a/src/lib/test-outbound/outbound-initiator.js
+++ b/src/lib/test-outbound/outbound-initiator.js
@@ -380,7 +380,8 @@ const sendRequest = (baseUrl, method, path, queryParams, headers, body, successC
         const syncResponse = {
           status: result.status,
           statusText: result.statusText,
-          data: result.data
+          body: result.data,
+          headers: result.headers
         }
         const curlRequest = result.request ? result.request.toCurl() : ''
 


### PR DESCRIPTION
The body in the sync response was passed in response.data instead of response.body in all the places.
Just want to standardise that like callback.body, so refactored all the test cases with response.body.