### PR TITLE
feat: callback rule updates to suppose patch notification test-scenarios

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -56,8 +56,9 @@
       "madeAt": 1645016523343
     },
     "1006975|socket.io>engine.io": {
-      "decision": "postpone",
-      "madeAt": 1645178029296
+      "decision": "ignore",
+      "madeAt": 1645526492871,
+      "expiresAt": 1648118482663
     },
     "1004876|express-validator>validator": {
       "decision": "fix",
@@ -92,20 +93,24 @@
       "madeAt": 1645016565690
     },
     "1004946|npm-audit-resolver>yargs-unparser>yargs>string-width>strip-ansi>ansi-regex": {
-      "decision": "postpone",
-      "madeAt": 1645177376186
+      "decision": "ignore",
+      "madeAt": 1645526498774,
+      "expiresAt": 1648118482663
     },
     "1004946|npm-audit-resolver>yargs-unparser>yargs>cliui>string-width>strip-ansi>ansi-regex": {
-      "decision": "postpone",
-      "madeAt": 1645177376186
+      "decision": "ignore",
+      "madeAt": 1645526498774,
+      "expiresAt": 1648118482663
     },
     "1004946|npm-audit-resolver>yargs-unparser>yargs>cliui>wrap-ansi>string-width>strip-ansi>ansi-regex": {
-      "decision": "postpone",
-      "madeAt": 1645177376186
+      "decision": "ignore",
+      "madeAt": 1645526498774,
+      "expiresAt": 1648118482663
     },
     "1004876|hapi-swagger>swagger-parser>z-schema>validator": {
-      "decision": "postpone",
-      "madeAt": 1645177375669
+      "decision": "ignore",
+      "madeAt": 1645526495866,
+      "expiresAt": 1648118482663
     }
   },
   "rules": {},

--- a/spec_files/rules_callback/default.json
+++ b/spec_files/rules_callback/default.json
@@ -1,5 +1,63 @@
 [
   {
+    "ruleId": 30,
+    "priority": 1,
+    "description": "ttkpayeefsp PUT Notifications Failure Test-case due to invalid FSPIOP-Destination",
+    "apiVersion": {
+      "minorVersion": 1,
+      "majorVersion": 1,
+      "type": "fspiop",
+      "asynchronous": true
+    },
+    "conditions": {
+      "all": [
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "testingtoolkitdfsp",
+          "path": "FSPIOP-Source"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "ttkpayeefsp",
+          "path": "FSPIOP-Destination"
+        },
+        {
+          "fact": "body",
+          "operator": "numericEqual",
+          "value": "104",
+          "path": "amount.amount"
+        },
+        {
+          "fact": "operationPath",
+          "operator": "equal",
+          "value": "/transfers"
+        },
+        {
+          "fact": "method",
+          "operator": "equal",
+          "value": "post"
+        }
+      ]
+    },
+    "event": {
+      "method": "put",
+      "path": "/transfers/{ID}",
+      "params": {
+        "headers": {
+          "FSPIOP-Destination": "doesnotexistfsp"
+        },
+        "scripts": {
+          "scriptingEngine": "postman"
+        }
+      },
+      "type": "MOCK_CALLBACK"
+    },
+    "type": "callback",
+    "version": 1
+  },
+  {
     "ruleId": 29,
     "priority": 1,
     "description": "ttkpayeefsp PATCH Notifications Failure Test-case due to invalid fulfilment",

--- a/spec_files/rules_callback/default.json
+++ b/spec_files/rules_callback/default.json
@@ -1,5 +1,136 @@
 [
   {
+    "ruleId": 28,
+    "priority": 1,
+    "description": "ttkpayeefsp PATCH Notifications Failure due to invalid fulfiment Test-case",
+    "apiVersion": {
+      "minorVersion": 1,
+      "majorVersion": 1,
+      "type": "fspiop",
+      "asynchronous": true
+    },
+    "conditions": {
+      "all": [
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "testingtoolkitdfsp",
+          "path": "FSPIOP-Source"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "ttkpayeefsp",
+          "path": "FSPIOP-Destination"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "application/vnd.interoperability.transfers+json;version=1.1",
+          "path": "Content-Type"
+        },
+        {
+          "fact": "body",
+          "operator": "numericEqual",
+          "value": "102",
+          "path": "amount.amount"
+        },
+        {
+          "fact": "operationPath",
+          "operator": "equal",
+          "value": "/transfers"
+        },
+        {
+          "fact": "method",
+          "operator": "equal",
+          "value": "post"
+        }
+      ]
+    },
+    "event": {
+      "method": "put",
+      "path": "/transfers/{ID}",
+      "params": {
+        "body": {
+          "fulfilment": "WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8",
+          "completedTimestamp": "{$function.generic.curDateISO}",
+          "transferState": "RESERVED",
+          "extensionList": null
+        },
+        "scripts": {
+          "scriptingEngine": "postman"
+        }
+      },
+      "type": "MOCK_CALLBACK"
+    },
+    "type": "callback",
+    "version": 1
+  },
+  {
+    "ruleId": 27,
+    "priority": 1,
+    "description": "ttkpayeefsp PATCH Notifications Success Test-case",
+    "apiVersion": {
+      "minorVersion": 1,
+      "majorVersion": 1,
+      "type": "fspiop",
+      "asynchronous": true
+    },
+    "conditions": {
+      "all": [
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "testingtoolkitdfsp",
+          "path": "FSPIOP-Source"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "ttkpayeefsp",
+          "path": "FSPIOP-Destination"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "application/vnd.interoperability.transfers+json;version=1.1",
+          "path": "Content-Type"
+        },
+        {
+          "fact": "body",
+          "operator": "numericEqual",
+          "value": "101",
+          "path": "amount.amount"
+        },
+        {
+          "fact": "operationPath",
+          "operator": "equal",
+          "value": "/transfers"
+        },
+        {
+          "fact": "method",
+          "operator": "equal",
+          "value": "post"
+        }
+      ]
+    },
+    "event": {
+      "method": "put",
+      "path": "/transfers/{ID}",
+      "params": {
+        "body": {
+          "transferState": "RESERVED"
+        },
+        "scripts": {
+          "scriptingEngine": "postman"
+        }
+      },
+      "type": "MOCK_CALLBACK"
+    },
+    "type": "callback",
+    "version": 1
+  },
+  {
     "ruleId": 20,
     "priority": 1,
     "description": "get /parties/{Type}/{ID} for pinkbank",

--- a/spec_files/rules_callback/default.json
+++ b/spec_files/rules_callback/default.json
@@ -2,7 +2,7 @@
   {
     "ruleId": 28,
     "priority": 1,
-    "description": "ttkpayeefsp PATCH Notifications Failure due to invalid fulfiment Test-case",
+    "description": "ttkpayeefsp PATCH Notifications Failure due to invalid FSPIOP-Destination",
     "apiVersion": {
       "minorVersion": 1,
       "majorVersion": 1,
@@ -51,8 +51,10 @@
       "method": "put",
       "path": "/transfers/{ID}",
       "params": {
+        "headers": {
+          "FSPIOP-Destination": "doesnotexistfsp"
+        },
         "body": {
-          "fulfilment": "WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8",
           "completedTimestamp": "{$function.generic.curDateISO}",
           "transferState": "RESERVED",
           "extensionList": null

--- a/spec_files/rules_callback/default.json
+++ b/spec_files/rules_callback/default.json
@@ -1,8 +1,75 @@
 [
   {
+    "ruleId": 29,
+    "priority": 1,
+    "description": "ttkpayeefsp PATCH Notifications Failure Test-case due to invalid fulfilment",
+    "apiVersion": {
+      "minorVersion": 1,
+      "majorVersion": 1,
+      "type": "fspiop",
+      "asynchronous": true
+    },
+    "conditions": {
+      "all": [
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "testingtoolkitdfsp",
+          "path": "FSPIOP-Source"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "ttkpayeefsp",
+          "path": "FSPIOP-Destination"
+        },
+        {
+          "fact": "headers",
+          "operator": "equal",
+          "value": "application/vnd.interoperability.transfers+json;version=1.1",
+          "path": "Content-Type"
+        },
+        {
+          "fact": "body",
+          "operator": "numericEqual",
+          "value": "103",
+          "path": "amount.amount"
+        },
+        {
+          "fact": "operationPath",
+          "operator": "equal",
+          "value": "/transfers"
+        },
+        {
+          "fact": "method",
+          "operator": "equal",
+          "value": "post"
+        }
+      ]
+    },
+    "event": {
+      "method": "put",
+      "path": "/transfers/{ID}",
+      "params": {
+        "body": {
+          "fulfilment": "WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8",
+          "completedTimestamp": "{$function.generic.curDateISO}",
+          "transferState": "RESERVED",
+          "extensionList": null
+        },
+        "scripts": {
+          "scriptingEngine": "postman"
+        }
+      },
+      "type": "MOCK_CALLBACK"
+    },
+    "type": "callback",
+    "version": 1
+  },
+  {
     "ruleId": 28,
     "priority": 1,
-    "description": "ttkpayeefsp PATCH Notifications Failure due to invalid FSPIOP-Destination",
+    "description": "ttkpayeefsp PATCH Notifications Failure Test-case due to invalid FSPIOP-Destination",
     "apiVersion": {
       "minorVersion": 1,
       "majorVersion": 1,
@@ -55,9 +122,7 @@
           "FSPIOP-Destination": "doesnotexistfsp"
         },
         "body": {
-          "completedTimestamp": "{$function.generic.curDateISO}",
-          "transferState": "RESERVED",
-          "extensionList": null
+          "transferState": "RESERVED"
         },
         "scripts": {
           "scriptingEngine": "postman"


### PR DESCRIPTION
Added callback rules:
- ttkpayeefsp PATCH Notifications Success Test-case - https://github.com/mojaloop/project/issues/2676
- ttkpayeefsp PATCH Notifications Failure due to invalid fulfiment Test-case - https://github.com/mojaloop/project/issues/2556
- ttkpayeefsp PUT Notifications Failure Test-case due to invalid FSPIOP-Destination  Test-case - https://github.com/mojaloop/project/issues/2697
- ttkpayeefsp PATCH Notifications Failure Test-case due to invalid FSPIOP-Destination Test-case - https://github.com/mojaloop/project/issues/2697
 
~Blocked by https://github.com/mojaloop/project/issues/2696~