### PR TITLE
feat: docker build for multi arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,29 +318,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setup buildx and qemu
+          name: Build Docker local image
           command: |
-            sudo apt-get update
-            sudo apt-get install -y qemu-user-static
-            sudo apt-get install -y binfmt-support
-      - run:
-          name: Check versions
-          command: |
-            qemu-aarch64-static --version
-            update-binfmts --version
-      - run:
-          name: Create builder and build Multi Arch Docker local image
-          command: |
-            export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker buildx create --name multi-arch-builder
-            docker buildx use multi-arch-builder
-            docker buildx inspect --bootstrap
-            docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
-      # - run:
-      #     name: Build Docker local image
-      #     command: |
-      #       echo "Building Docker image: local"
-      #       docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
+            echo "Building Docker image: local"
+            docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       - run:
           name: Save docker image to workspace
           command: docker save -o /tmp/docker-image-local.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local
@@ -611,27 +592,28 @@ jobs:
             echo "export SLACK_RELEASE_TAG=v${CIRCLE_TAG:1}" >> $BASH_ENV
             echo "export SLACK_BUILD_ID=${CIRCLE_BUILD_NUM}" >> $BASH_ENV
             echo "export SLACK_CI_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
-      - attach_workspace:
-          at: /tmp
       - run:
-          name: Load the pre-built docker image from workspace
-          command: | 
-            docker load -i /tmp/docker-image.tar
+          name: Setup buildx and qemu
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
+          name: Check versions
+          command: |
+            qemu-aarch64-static --version
+            update-binfmts --version
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
-          name: Re-tag pre built image
+          name: Build Multi Arch Docker image and push
           command: |
-            docker tag $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      - run:
-          name: Publish Docker image $CIRCLE_TAG & Latest tag to Docker Hub
-          command: |
-            echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
-            docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-            echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
-            docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker buildx create --name multi-arch-builder
+            docker buildx use multi-arch-builder
+            docker buildx inspect --bootstrap
+            docker buildx build --platform linux/amd64,linux/arm64 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
       # - run:
       #     name: Set Image Digest
       #     command: |
@@ -866,6 +848,7 @@ workflows:
       - publish-snapshot:
           context: org-global
           requires:
+            - setup
             ## TODO: Commenting out following for testing. Need to re-enable them
             # - pr-tools/pr-title-check
             # - test-dependencies
@@ -879,7 +862,6 @@ workflows:
             # - audit-licenses
             # - license-scan
             # - image-scan
-            - build-local
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*\-snapshot+((\.[0-9]+)?)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,7 +613,7 @@ jobs:
             docker buildx create --name multi-arch-builder
             docker buildx use multi-arch-builder
             docker buildx inspect --bootstrap
-            docker buildx build --platform linux/amd64,linux/arm64 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
       # - run:
       #     name: Set Image Digest
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,21 +329,18 @@ jobs:
             qemu-aarch64-static --version
             update-binfmts --version
       - run:
-          name: Create builder
+          name: Create builder and build Multi Arch Docker local image
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
             docker buildx create --name multi-arch-builder
             docker buildx use multi-arch-builder
             docker buildx inspect --bootstrap
+            docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       # - run:
       #     name: Build Docker local image
       #     command: |
       #       echo "Building Docker image: local"
       #       docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
-      - run:
-          name: Build Multi Arch Docker local image
-          command: | 
-            DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       - run:
           name: Save docker image to workspace
           command: docker save -o /tmp/docker-image-local.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local
@@ -634,22 +631,23 @@ jobs:
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
             echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      - run:
-          name: Set Image Digest
-          command: |
-            IMAGE_DIGEST=$(docker inspect $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
-            echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
-            echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
-      - run:
-          name: Update Slack config
-          command: |
-            echo "export SLACK_RELEASE_URL='https://hub.docker.com/layers/${CIRCLE_PROJECT_REPONAME}/${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}/v${CIRCLE_TAG:1}/images/${IMAGE_DIGEST}?context=explore'" | sed -r "s/${DOCKER_ORG}\/${CIRCLE_PROJECT_REPONAME}@sha256:/sha256-/g" >> $BASH_ENV
-      - slack/notify:
-          event: pass
-          template: SLACK_TEMP_RELEASE_SUCCESS
-      - slack/notify:
-          event: fail
-          template: SLACK_TEMP_RELEASE_FAILURE
+      
+      # - run:
+      #     name: Set Image Digest
+      #     command: |
+      #       IMAGE_DIGEST=$(docker inspect $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
+      #       echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
+      #       echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
+      # - run:
+      #     name: Update Slack config
+      #     command: |
+      #       echo "export SLACK_RELEASE_URL='https://hub.docker.com/layers/${CIRCLE_PROJECT_REPONAME}/${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}/v${CIRCLE_TAG:1}/images/${IMAGE_DIGEST}?context=explore'" | sed -r "s/${DOCKER_ORG}\/${CIRCLE_PROJECT_REPONAME}@sha256:/sha256-/g" >> $BASH_ENV
+      # - slack/notify:
+      #     event: pass
+      #     template: SLACK_TEMP_RELEASE_SUCCESS
+      # - slack/notify:
+      #     event: fail
+      #     template: SLACK_TEMP_RELEASE_FAILURE
 
 ##
 # Workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,10 +318,32 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build Docker local image
+          name: Setup buildx and qemu
           command: |
-            echo "Building Docker image: local"
-            docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
+          name: Check versions
+          command: |
+            qemu-aarch64-static --version
+            update-binfmts --version
+      - run:
+          name: Create builder
+          command: |
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker buildx create --name multi-arch-builder
+            docker buildx use multi-arch-builder
+            docker buildx inspect --bootstrap
+      # - run:
+      #     name: Build Docker local image
+      #     command: |
+      #       echo "Building Docker image: local"
+      #       docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
+      - run:
+          name: Build Multi Arch Docker local image
+          command: | 
+            DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       - run:
           name: Save docker image to workspace
           command: docker save -o /tmp/docker-image-local.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local
@@ -846,18 +868,20 @@ workflows:
       - publish-snapshot:
           context: org-global
           requires:
-            - pr-tools/pr-title-check
-            - test-dependencies
-            - test-lint
-            - test-unit
-            - test-coverage
-            - test-functional
-            ## Currently not implemented
-            # - test-integration
-            - vulnerability-check
-            - audit-licenses
-            - license-scan
-            - image-scan
+            ## TODO: Commenting out following for testing. Need to re-enable them
+            # - pr-tools/pr-title-check
+            # - test-dependencies
+            # - test-lint
+            # - test-unit
+            # - test-coverage
+            # - test-functional
+            # ## Currently not implemented
+            # # - test-integration
+            # - vulnerability-check
+            # - audit-licenses
+            # - license-scan
+            # - image-scan
+            - build-local
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*\-snapshot+((\.[0-9]+)?)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,10 +318,28 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Setup buildx and qemu
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
+          name: Check versions
+          command: |
+            qemu-aarch64-static --version
+            update-binfmts --version
+      - run:
+          name: Login to Docker Hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
           name: Build Docker local image
           command: |
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker buildx create --name multi-arch-builder
+            docker buildx use multi-arch-builder
+            docker buildx inspect --bootstrap
             echo "Building Docker image: local"
-            docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
+            docker buildx build --platform linux/amd64 --load -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       - run:
           name: Save docker image to workspace
           command: docker save -o /tmp/docker-image-local.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local
@@ -330,27 +348,6 @@ jobs:
           paths:
             - ./docker-image-local.tar
 
-  build:
-    executor: default-machine
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Load the pre-built docker local image from workspace
-          command: docker load -i /tmp/docker-image-local.tar
-      - run:
-          name: Re-tag the image
-          command: |
-            echo "Re-tagging Docker image: $CIRCLE_TAG"
-            docker tag $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-      - run:
-          name: Save the new docker image to workspace
-          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - ./docker-image.tar
-
   license-scan:
     executor: default-machine
     steps:
@@ -358,12 +355,12 @@ jobs:
           at: /tmp
       - run:
           name: Load the pre-built docker image from workspace
-          command: docker load -i /tmp/docker-image.tar
+          command: docker load -i /tmp/docker-image-local.tar
       - run:
           <<: *defaults_license_scanner
       - run:
           name: Run the license-scanner
-          command: cd /tmp/license-scanner && mode=docker dockerImages=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG make run
+          command: cd /tmp/license-scanner && mode=docker dockerImages=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local make run
       - store_artifacts:
           path: /tmp/license-scanner/results
           prefix: licenses
@@ -403,7 +400,7 @@ jobs:
           at: /tmp
       - run:
           name: Load the pre-built docker image from workspace
-          command: docker load -i /tmp/docker-image.tar
+          command: docker load -i /tmp/docker-image-local.tar
       - run:
           name: Download the mojaloop/ci-config repo
           command: |
@@ -419,7 +416,7 @@ jobs:
       - anchore/analyze_local_image:
           # Force the older version, version 0.7.0 was just published, and is broken
           anchore_version: v0.6.1
-          image_name: "docker.io/node:16.15.0-alpine $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
+          image_name: "docker.io/node:16.15.0-alpine $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local"
           policy_failure: false
           timeout: '500'
           # Note: if the generated policy is invalid, this will fallback to the default policy, which we don't want!
@@ -534,26 +531,30 @@ jobs:
             echo "export SLACK_RELEASE_TAG=v${CIRCLE_TAG:1}" >> $BASH_ENV
             echo "export SLACK_BUILD_ID=${CIRCLE_BUILD_NUM}" >> $BASH_ENV
             echo "export SLACK_CI_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
-      - attach_workspace:
-          at: /tmp
       - run:
-          name: Load the pre-built docker image from workspace
-          command: | 
-            docker load -i /tmp/docker-image.tar
+          name: Setup buildx and qemu
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
+          name: Check versions
+          command: |
+            qemu-aarch64-static --version
+            update-binfmts --version
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
-          name: Re-tag pre built image
+          name: Build Multi Arch Docker image and push
           command: |
-            docker tag $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      - run:
-          name: Publish Docker image $CIRCLE_TAG & Latest tag to Docker Hub
-          command: |
-            echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
-            docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-            echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
-            docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker buildx create --name multi-arch-builder
+            docker buildx use multi-arch-builder
+            docker buildx inspect --bootstrap
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+            echo "Published $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
+            echo "Published $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
       - run:
           name: Set Image Digest
           command: |
@@ -614,22 +615,24 @@ jobs:
             docker buildx use multi-arch-builder
             docker buildx inspect --bootstrap
             docker buildx build --platform linux/amd64,linux/arm64 --push -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
-      # - run:
-      #     name: Set Image Digest
-      #     command: |
-      #       IMAGE_DIGEST=$(docker inspect $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
-      #       echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
-      #       echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
-      # - run:
-      #     name: Update Slack config
-      #     command: |
-      #       echo "export SLACK_RELEASE_URL='https://hub.docker.com/layers/${CIRCLE_PROJECT_REPONAME}/${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}/v${CIRCLE_TAG:1}/images/${IMAGE_DIGEST}?context=explore'" | sed -r "s/${DOCKER_ORG}\/${CIRCLE_PROJECT_REPONAME}@sha256:/sha256-/g" >> $BASH_ENV
-      # - slack/notify:
-      #     event: pass
-      #     template: SLACK_TEMP_RELEASE_SUCCESS
-      # - slack/notify:
-      #     event: fail
-      #     template: SLACK_TEMP_RELEASE_FAILURE
+            echo "Published $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
+            echo "Published $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
+      - run:
+          name: Set Image Digest
+          command: |
+            IMAGE_DIGEST=$(docker inspect $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
+            echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
+            echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
+      - run:
+          name: Update Slack config
+          command: |
+            echo "export SLACK_RELEASE_URL='https://hub.docker.com/layers/${CIRCLE_PROJECT_REPONAME}/${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}/v${CIRCLE_TAG:1}/images/${IMAGE_DIGEST}?context=explore'" | sed -r "s/${DOCKER_ORG}\/${CIRCLE_PROJECT_REPONAME}@sha256:/sha256-/g" >> $BASH_ENV
+      - slack/notify:
+          event: pass
+          template: SLACK_TEMP_RELEASE_SUCCESS
+      - slack/notify:
+          event: fail
+          template: SLACK_TEMP_RELEASE_FAILURE
 
 ##
 # Workflows
@@ -754,30 +757,10 @@ workflows:
               ignore:
                 - /feature*/
                 - /bugfix*/
-      - build:
-          context: org-global
-          requires:
-            - setup
-            - test-dependencies
-            - test-lint
-            - test-unit
-            - test-coverage
-            - test-functional
-            ## Currently not implemented
-            # - test-integration
-            - vulnerability-check
-            - audit-licenses
-            - build-local
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(\-snapshot(\.[0-9]+)?)?(\-hotfix(\.[0-9]+)?)?(\-perf(\.[0-9]+)?)?/
-            branches:
-              ignore:
-                - /.*/
       - license-scan:
           context: org-global
           requires:
-            - build
+            - build-local
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-snapshot(\.[0-9]+)?)?(\-hotfix(\.[0-9]+)?)?(\-perf(\.[0-9]+)?)?/
@@ -787,7 +770,7 @@ workflows:
       - image-scan:
           context: org-global
           requires:
-            - build
+            - build-local
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-snapshot(\.[0-9]+)?)?(\-hotfix(\.[0-9]+)?)?(\-perf(\.[0-9]+)?)?/
@@ -848,20 +831,18 @@ workflows:
       - publish-snapshot:
           context: org-global
           requires:
-            - setup
-            ## TODO: Commenting out following for testing. Need to re-enable them
-            # - pr-tools/pr-title-check
-            # - test-dependencies
-            # - test-lint
-            # - test-unit
-            # - test-coverage
-            # - test-functional
-            # ## Currently not implemented
-            # # - test-integration
-            # - vulnerability-check
-            # - audit-licenses
-            # - license-scan
-            # - image-scan
+            - pr-tools/pr-title-check
+            - test-dependencies
+            - test-lint
+            - test-unit
+            - test-coverage
+            - test-functional
+            ## Currently not implemented
+            # - test-integration
+            - vulnerability-check
+            - audit-licenses
+            - license-scan
+            - image-scan
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*\-snapshot+((\.[0-9]+)?)/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "16.1.0-snapshot.0",
+  "version": "16.1.0-snapshot.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-testing-toolkit",
-      "version": "16.1.0-snapshot.0",
+      "version": "16.1.0-snapshot.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "16.0.0",
+  "version": "16.1.0-snapshot.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-testing-toolkit",
-      "version": "16.0.0",
+      "version": "16.1.0-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "16.1.0-snapshot.2",
+  "version": "16.1.0-snapshot.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-testing-toolkit",
-      "version": "16.1.0-snapshot.2",
+      "version": "16.1.0-snapshot.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "16.1.0-snapshot.3",
+  "version": "16.1.0-snapshot.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-testing-toolkit",
-      "version": "16.1.0-snapshot.3",
+      "version": "16.1.0-snapshot.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-testing-toolkit",
-  "version": "16.1.0-snapshot.1",
+  "version": "16.1.0-snapshot.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-testing-toolkit",
-      "version": "16.1.0-snapshot.1",
+      "version": "16.1.0-snapshot.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "16.1.0-snapshot.2",
+  "version": "16.1.0-snapshot.3",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc. ",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "16.1.0-snapshot.1",
+  "version": "16.1.0-snapshot.2",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc. ",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "16.1.0-snapshot.0",
+  "version": "16.1.0-snapshot.1",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc. ",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "16.0.0",
+  "version": "16.1.0-snapshot.0",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc. ",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-testing-toolkit",
   "description": "Testing Toolkit for Mojaloop implementations",
-  "version": "16.1.0-snapshot.3",
+  "version": "16.1.0-snapshot.4",
   "license": "Apache-2.0",
   "author": "Vijaya Kumar Guthi, ModusBox Inc. ",
   "contributors": [


### PR DESCRIPTION
Refactored build, build-local, publish-snapshot and publish jobs in circleCI to build docker images using buildx.
This is to support multiple architectures apart from amd64 like arm64. This enables Apple Macbook users with apple silicon chips to run TTK locally without any x86 emulation.

**_Issue: Currently the `image-scan` step is failing if we build the docker image using buildx. Need to investigate the cause and fix it._**