### PR TITLE
feat: enhance user config loading functions, tracing and mocking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "nodemon": "3.1.9",
-        "npm-check-updates": "17.1.16",
+        "npm-check-updates": "17.1.18",
         "nyc": "17.1.0",
         "parse-strings-in-object": "1.6.0",
         "pre-commit": "1.2.2",
@@ -11110,10 +11110,11 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.16",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.16.tgz",
-      "integrity": "sha512-9nohkfjLRzLfsLVGbO34eXBejvrOOTuw5tvNammH73KEFG5XlFoi3G2TgjTExHtnrKWCbZ+mTT+dbNeSjASIPw==",
+      "version": "17.1.18",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.18.tgz",
+      "integrity": "sha512-bkUy2g4v1i+3FeUf5fXMLbxmV95eG4/sS7lYE32GrUeVgQRfQEk39gpskksFunyaxQgTIdrvYbnuNbO/pSUSqw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
         "npm-check-updates": "build/cli.js"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "nodemon": "3.1.9",
-    "npm-check-updates": "17.1.16",
+    "npm-check-updates": "17.1.18",
     "nyc": "17.1.0",
     "parse-strings-in-object": "1.6.0",
     "pre-commit": "1.2.2",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -70,30 +70,30 @@ const setStoredUserConfig = async (newConfig, user) => {
   }
 }
 
-const loadUserConfig = async (user) => {
+const loadUserConfig = async (user, filename = USER_CONFIG_FILE) => {
   try {
-    USER_CONFIG[user ? user.dfspId : 'data'] = await loadUserConfigDFSPWise(user)
+    USER_CONFIG[user ? user.dfspId : 'data'] = await loadUserConfigDFSPWise(user, filename)
   } catch (err) {
     console.log(`Can not read the file ${USER_CONFIG_FILE}`, err)
   }
   return true
 }
 
-const loadUserConfigDFSPWise = async (user) => {
-  const userConfig = await storageAdapter.read(USER_CONFIG_FILE, user)
+const loadUserConfigDFSPWise = async (user, filename = USER_CONFIG_FILE) => {
+  const userConfig = await storageAdapter.read(filename, user)
   return userConfig.data
 }
 
-const loadSystemConfig = async () => {
+const loadSystemConfig = async (filename = SYSTEM_CONFIG_FILE) => {
   try {
-    SYSTEM_CONFIG = (await storageAdapter.read(SYSTEM_CONFIG_FILE)).data
+    SYSTEM_CONFIG = (await storageAdapter.read(filename)).data
     const systemConfigFromEnvironment = _getSystemConfigFromEnvironment()
     _.merge(SYSTEM_CONFIG, systemConfigFromEnvironment)
     const secretsFromEnvironment = _getSecretsFromEnvironment()
     console.log(secretsFromEnvironment)
     _.merge(SYSTEM_CONFIG, secretsFromEnvironment)
   } catch (err) {
-    console.log(`Can not read the file ${SYSTEM_CONFIG_FILE}`, err)
+    console.log(`Can not read the file ${filename}`, err)
   }
   return true
 }

--- a/src/lib/mocking/middleware-functions/ilpModel.js
+++ b/src/lib/mocking/middleware-functions/ilpModel.js
@@ -220,8 +220,8 @@ const validateTransferCondition = (context, request) => {
 
 // Decoding functions
 
-const getIlpTransactionObject = (ilpPacket) => {
-  return ilpObj.getTransactionObject(ilpPacket)
+const getIlpTransactionObject = (ilpPacket, isIso20022) => {
+  return isIso20022 ? ilpV4Obj.getTransactionObject(ilpPacket) : ilpObj.getTransactionObject(ilpPacket)
 }
 
 const _isIso20022 = (requestOrResponse) => {

--- a/src/lib/mocking/middleware-functions/quotesAssociation.js
+++ b/src/lib/mocking/middleware-functions/quotesAssociation.js
@@ -50,7 +50,8 @@ const handleTransfers = (context, request) => {
     try {
       ilpTransactionObject = IlpModel.getIlpTransactionObject(
         request.payload.ilpPacket ||
-        request.payload.CdtTrfTxInf?.VrfctnOfTerms?.IlpV4PrepPacket
+        request.payload.CdtTrfTxInf?.VrfctnOfTerms?.IlpV4PrepPacket,
+        !!request.payload.CdtTrfTxInf?.VrfctnOfTerms?.IlpV4PrepPacket
       )
     } catch (err) {
       return false

--- a/src/lib/rulesEngineModel.js
+++ b/src/lib/rulesEngineModel.js
@@ -395,6 +395,31 @@ const addTypeAndVersion = (model, fileContent) => {
   }
 }
 
+// used for integration tests
+const setTestRules = async({
+  response,
+  validation,
+  callback,
+  forward
+}) => {
+  if (response) {
+    model.data.response.rules = (await storageAdapter.read(response)).data
+    loadRules(model.data.response, model.data.response.rules)
+  }
+  if (validation) {
+    model.data.validation.rules = (await storageAdapter.read(validation)).data
+    loadRules(model.data.validation, model.data.validation.rules)
+  }
+  if (callback) {
+    model.data.callback.rules = (await storageAdapter.read(callback)).data
+    loadRules(model.data.callback, model.data.callback.rules)
+  }
+  if (forward) {
+    model.data.forward.rules = (await storageAdapter.read(forward)).data
+    loadRules(model.data.forward, model.data.forward.rules)
+  }
+}
+
 module.exports = {
   getModel,
 
@@ -432,5 +457,7 @@ module.exports = {
   getForwardRulesFiles,
   getForwardRulesFileContent,
   setForwardRulesFileContent,
-  deleteForwardRulesFile
+  deleteForwardRulesFile,
+
+  setTestRules
 }

--- a/src/lib/rulesEngineModel.js
+++ b/src/lib/rulesEngineModel.js
@@ -396,7 +396,7 @@ const addTypeAndVersion = (model, fileContent) => {
 }
 
 // used for integration tests
-const setTestRules = async({
+const setTestRules = async ({
   response,
   validation,
   callback,

--- a/src/lib/test-outbound/outbound-initiator.js
+++ b/src/lib/test-outbound/outbound-initiator.js
@@ -307,11 +307,15 @@ const processTestCase = async (
     const requestTraceId = saveReport ? crypto.randomBytes(16).toString('hex') : traceID
 
     // Insert traceparent header if sessionID passed
-    if (tracing.sessionID) {
+    if (tracing.sessionID || saveReport) {
       convertedRequest.headers = convertedRequest.headers || {}
       convertedRequest.headers.traceparent = '00-' + requestTraceId + '-' + String(testCaseIndex).padStart(8, '0') + String(requestIndex).padStart(8, '0') + '-01'
       // todo: think about proper traceparent header
     }
+
+    let baggage = convertedRequest.headers.baggage || '';
+    if (baggage) baggage = baggage + ',';
+    convertedRequest.headers.baggage = baggage + `testCaseId=${testCase.id},requestId=${request.id}`
 
     const scriptsExecution = {}
     let contextObj = null

--- a/src/lib/test-outbound/outbound-initiator.js
+++ b/src/lib/test-outbound/outbound-initiator.js
@@ -313,8 +313,8 @@ const processTestCase = async (
       // todo: think about proper traceparent header
     }
 
-    let baggage = convertedRequest.headers.baggage || '';
-    if (baggage) baggage = baggage + ',';
+    let baggage = convertedRequest.headers.baggage || ''
+    if (baggage) baggage = baggage + ','
     convertedRequest.headers.baggage = baggage + `testCaseId=${testCase.id},requestId=${request.id}`
 
     const scriptsExecution = {}

--- a/test/unit/lib/rulesEngineModel.test.js
+++ b/test/unit/lib/rulesEngineModel.test.js
@@ -53,7 +53,7 @@ describe('RulesEngineModel', () => {
   describe('model', () => {
     it('getModel should return the model', async () => {
       const result = await RulesEngineModel.getModel(undefined, 'response')
-      expect(result).toBeDefined()      
+      expect(result).toBeDefined()
     })
     it('getModel should return the model', async () => {
       dbAdapter.read.mockResolvedValue({
@@ -61,7 +61,7 @@ describe('RulesEngineModel', () => {
       })
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.getModel({dfspId: 'userdfsp'}, 'response')
-      expect(result).toBeDefined()      
+      expect(result).toBeDefined()
     })
     it('getModel should return the model', async () => {
       dbAdapter.read.mockResolvedValue({
@@ -70,7 +70,7 @@ describe('RulesEngineModel', () => {
         }
       })
       const result = await RulesEngineModel.getModel({dfspId: 'userdfsp'}, 'response')
-      expect(result).toBeDefined()      
+      expect(result).toBeDefined()
     })
   })
   describe('response', () => {
@@ -79,7 +79,7 @@ describe('RulesEngineModel', () => {
     })
     it('getResponseRulesEngine with a parameter should not reload rules', async () => {
       const result = await RulesEngineModel.getResponseRulesEngine([])
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('reloadResponseRules when active rules file is found with no rule conditions', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({
@@ -87,7 +87,7 @@ describe('RulesEngineModel', () => {
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.reloadResponseRules()
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('reloadResponseRules when active rules file is found with rule conditions', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({
@@ -122,9 +122,9 @@ describe('RulesEngineModel', () => {
           "type": "MOCK_RESPONSE"
         }
       }]))
-      
+
       const result = await RulesEngineModel.reloadResponseRules()
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('reloadResponseRules when active rules file is not found', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({
@@ -138,19 +138,19 @@ describe('RulesEngineModel', () => {
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({activeRulesFile: 'test.json'}))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setActiveResponseRulesFile('test.json')
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('getResponseRules should reload rules if not loaded', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.getResponseRules()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getResponseRules should return stored rules', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.getResponseRules()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getResponseRulesEngine should return rulesEngine', async () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({
@@ -158,17 +158,17 @@ describe('RulesEngineModel', () => {
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.getResponseRulesEngine()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getResponseRulesFiles should return activeRulesFile', async () => {
       SpyReadDirAsync.mockResolvedValue(['test.json', 'config.json'])
       const result = await RulesEngineModel.getResponseRulesFiles()
-      expect(result).not.toBeNull()      
+      expect(result).not.toBeNull()
     })
     it('getResponseRulesFiles should return null', async () => {
       SpyReadDirAsync.mockRejectedValueOnce()
       const result = await RulesEngineModel.getResponseRulesFiles()
-      expect(result).toBeNull()   
+      expect(result).toBeNull()
     })
     it('deleteResponseRulesFile should return true', async () => {
       SpyDeleteFileAsync.mockResolvedValue()
@@ -176,14 +176,14 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.deleteResponseRulesFile('test.json')
-      expect(result).toBeTruthy()  
+      expect(result).toBeTruthy()
     })
     it('deleteResponseRulesFile should return error', async () => {
       SpyDeleteFileAsync.mockRejectedValueOnce({message: 'error'})
       const result = await RulesEngineModel.deleteResponseRulesFile('test.json')
-      expect(result).toStrictEqual({message: 'error'})  
+      expect(result).toStrictEqual({message: 'error'})
     })
     it('setResponseRulesFileContent should return true', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -199,9 +199,9 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setResponseRulesFileContent('test.json', fileContent)
-      expect(result).toBeTruthy() 
+      expect(result).toBeTruthy()
     })
     it('setResponseRulesFileContent should return true', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -218,9 +218,9 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setResponseRulesFileContent('test.json', fileContent)
-      expect(result).toBeTruthy() 
+      expect(result).toBeTruthy()
     })
     it('setResponseRulesFileContent should return error', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -248,49 +248,49 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.reloadCallbackRules()
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('setActiveCallbackRulesFile should set activeRulesFile', async () => {
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({activeRulesFile: 'activeRulesFile'}))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setActiveCallbackRulesFile('test.json')
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('getCallbackRules should return stored rules', async () => {
       const result = await RulesEngineModel.getCallbackRules()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getCallbackRulesEngine should return rulesEngine', async () => {
       const result = await RulesEngineModel.getCallbackRulesEngine()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getCallbackRulesFiles should return activeRulesFile', async () => {
       SpyReadDirAsync.mockResolvedValue(['test.json', 'config.json'])
       const result = await RulesEngineModel.getCallbackRulesFiles()
-      expect(result).not.toBeNull()      
+      expect(result).not.toBeNull()
     })
     it('getCallbackRulesFiles should return null', async () => {
       SpyReadDirAsync.mockRejectedValueOnce()
       const result = await RulesEngineModel.getCallbackRulesFiles()
-      expect(result).toBeNull()   
+      expect(result).toBeNull()
     })
     it('deleteCallbackRulesFile should return true', async () => {
       SpyDeleteFileAsync.mockResolvedValue()
       SpyWriteFileAsync.mockResolvedValue(JSON.stringify({
         activeRulesFile: 'activeRulesFile'
       }))
-      
+
       const result = await RulesEngineModel.deleteCallbackRulesFile('test.json')
-      expect(result).toBeTruthy()  
+      expect(result).toBeTruthy()
     })
     it('deleteCallbackRulesFile should return error', async () => {
       SpyDeleteFileAsync.mockRejectedValueOnce({message: 'error'})
       const result = await RulesEngineModel.deleteCallbackRulesFile('test.json')
-      expect(result).toStrictEqual({message: 'error'})  
+      expect(result).toStrictEqual({message: 'error'})
     })
     it('setCallbackRulesFileContent should return true', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -303,9 +303,9 @@ describe('RulesEngineModel', () => {
       }]
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setCallbackRulesFileContent('test.json', fileContent)
-      expect(result).toBeTruthy() 
+      expect(result).toBeTruthy()
     })
     it('setCallbackRulesFileContent should return error', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -333,35 +333,35 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.reloadValidationRules()
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('setActiveValidationRulesFile should set activeRulesFile', async () => {
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({activeRulesFile: 'activeRulesFile'}))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setActiveValidationRulesFile('test.json')
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('getValidationRules should return stored rules', async () => {
       const result = await RulesEngineModel.getValidationRules()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getValidationRulesEngine should return rulesEngine', async () => {
       const result = await RulesEngineModel.getValidationRulesEngine()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getValidationRulesFiles should return activeRulesFile', async () => {
       SpyReadDirAsync.mockResolvedValue(['test.json', 'config.json'])
       const result = await RulesEngineModel.getValidationRulesFiles()
-      expect(result).not.toBeNull()      
+      expect(result).not.toBeNull()
     })
     it('getValidationRulesFiles should return null', async () => {
       SpyReadDirAsync.mockRejectedValueOnce()
       const result = await RulesEngineModel.getValidationRulesFiles()
-      expect(result).toBeNull()   
+      expect(result).toBeNull()
     })
     it('deleteValidationRulesFile should return true', async () => {
       SpyDeleteFileAsync.mockResolvedValue()
@@ -369,14 +369,14 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.deleteValidationRulesFile('test.json')
-      expect(result).toBeTruthy()  
+      expect(result).toBeTruthy()
     })
     it('deleteValidationRulesFile should return error', async () => {
       SpyDeleteFileAsync.mockRejectedValueOnce({message: 'error'})
       const result = await RulesEngineModel.deleteValidationRulesFile('test.json')
-      expect(result).toStrictEqual({message: 'error'})  
+      expect(result).toStrictEqual({message: 'error'})
     })
     it('setValidationRulesFileContent should return true', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -391,9 +391,9 @@ describe('RulesEngineModel', () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({
         activeRulesFile: 'activeRulesFile'
       }))
-      
+
       const result = await RulesEngineModel.setValidationRulesFileContent('test.json', fileContent)
-      expect(result).toBeTruthy() 
+      expect(result).toBeTruthy()
     })
     it('setValidationRulesFileContent should return error', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -421,49 +421,49 @@ describe('RulesEngineModel', () => {
         activeRulesFile: 'activeRulesFile'
       }))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.reloadForwardRules()
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('setActiveForwardRulesFile should set activeRulesFile', async () => {
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify({activeRulesFile: 'activeRulesFile'}))
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setActiveForwardRulesFile('test.json')
-      expect(result).toBeUndefined()      
+      expect(result).toBeUndefined()
     })
     it('getForwardRules should return stored rules', async () => {
       const result = await RulesEngineModel.getForwardRules()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getForwardRulesEngine should return rulesEngine', async () => {
       const result = await RulesEngineModel.getForwardRulesEngine()
-      expect(result).not.toBeUndefined()      
+      expect(result).not.toBeUndefined()
     })
     it('getForwardRulesFiles should return activeRulesFile', async () => {
       SpyReadDirAsync.mockResolvedValue(['test.json', 'config.json'])
       const result = await RulesEngineModel.getForwardRulesFiles()
-      expect(result).not.toBeNull()      
+      expect(result).not.toBeNull()
     })
     it('getForwardRulesFiles should return null', async () => {
       SpyReadDirAsync.mockRejectedValueOnce()
       const result = await RulesEngineModel.getForwardRulesFiles()
-      expect(result).toBeNull()   
+      expect(result).toBeNull()
     })
     it('deleteForwardRulesFile should return true', async () => {
       SpyDeleteFileAsync.mockResolvedValue()
       SpyWriteFileAsync.mockResolvedValue(JSON.stringify({
         activeRulesFile: 'activeRulesFile'
       }))
-      
+
       const result = await RulesEngineModel.deleteForwardRulesFile('test.json')
-      expect(result).toBeTruthy()  
+      expect(result).toBeTruthy()
     })
     it('deleteForwardRulesFile should return error', async () => {
       SpyDeleteFileAsync.mockRejectedValueOnce({message: 'error'})
       const result = await RulesEngineModel.deleteForwardRulesFile('test.json')
-      expect(result).toStrictEqual({message: 'error'})  
+      expect(result).toStrictEqual({message: 'error'})
     })
     it('setForwardRulesFileContent should return true', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -476,9 +476,9 @@ describe('RulesEngineModel', () => {
       }]
       SpyWriteFileAsync.mockResolvedValue()
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
-      
+
       const result = await RulesEngineModel.setForwardRulesFileContent('test.json', fileContent)
-      expect(result).toBeTruthy() 
+      expect(result).toBeTruthy()
     })
     it('setForwardRulesFileContent should return error', async () => {
       SpyGetSystemConfig.mockReturnValueOnce({
@@ -497,6 +497,25 @@ describe('RulesEngineModel', () => {
       SpyReadFileAsync.mockResolvedValue(JSON.stringify([]))
       const result = await RulesEngineModel.getForwardRulesFileContent('test.json')
       expect(result).toStrictEqual([])
+    })
+    it('setTestRules should set test rules', async () => {
+      const response = 'response.json'
+      const validation = 'validation.json'
+      const callback = 'callback.json'
+      const forward = 'forward.json'
+      const rules = [{conditions: {all: []}, event: {type: 'mock'}, priority: 1}]
+      const rulesString = JSON.stringify(rules)
+      SpyReadFileAsync.mockResolvedValueOnce(rulesString)
+      SpyReadFileAsync.mockResolvedValueOnce(rulesString)
+      SpyReadFileAsync.mockResolvedValueOnce(rulesString)
+      SpyReadFileAsync.mockResolvedValueOnce(rulesString)
+
+      await RulesEngineModel.setTestRules({ response, validation, callback, forward })
+
+      expect(await RulesEngineModel.getResponseRules()).toStrictEqual(rules)
+      expect(await RulesEngineModel.getValidationRules()).toStrictEqual(rules)
+      expect(await RulesEngineModel.getCallbackRules()).toStrictEqual(rules)
+      expect(await RulesEngineModel.getForwardRules()).toStrictEqual(rules)
     })
   })
 })


### PR DESCRIPTION
- Provide ability to load specific files for user config, system config and rules without enforcing the usage of the TTK in a container
- Properly handle ISO 20022 in `getIlpTransactionObject`
- Send the test case id and request id in the baggage header, to easily associate errors with the test cases
- Always generate traces for saved reports